### PR TITLE
comment first and last line of request.text, such that numpy.loadtxt …

### DIFF
--- a/crspectra/_crspectra.py
+++ b/crspectra/_crspectra.py
@@ -146,8 +146,11 @@ class CRSpectra:
 
         converters = {7: fabs, 9: fabs}
 
+        reqtext = "#" + request.text
+        reqtext = reqtext[:reqtext.rindex("\n")+1] + "#" + reqtext[reqtext.rindex("\n")+1:]
+
         result = numpy.loadtxt(
-            io.StringIO(request.text), dtype, converters=converters,
+            io.StringIO(reqtext), dtype, converters=converters,
             usecols=(3, 6, 7, 8, 9, 10, 15))
 
         return result


### PR DESCRIPTION
…does not break

When trying to query the data, request.text has a first and last line of only text, which is not commented. numpy.loadtxt tries to load this and the number of columns do not match and it throws an error. Commenting the first and last line fixes this. 